### PR TITLE
feat: Copy Deck + Options dropdown

### DIFF
--- a/app/api/decks/[id]/copy/route.ts
+++ b/app/api/decks/[id]/copy/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { deckService } from "@/app/lib/services/deckService";
+import { deckDbService } from "@/app/lib/db/services/deckDbService";
+import { ObjectId } from "mongodb";
+
+/**
+ * POST /api/decks/[id]/copy
+ * Duplicate a deck into the current user's account.
+ * - Clears youtubeUrl
+ * - Defaults to private (isPublic=false)
+ * - Resets metrics (likes/views via schema defaults)
+ * - Appends "(Copy from {owner})" to the name
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const resolvedParams = await params;
+    const sourceDeckId = resolvedParams.id;
+
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    // Load source deck
+    const sourceDeck = await deckService.getDeckById(sourceDeckId);
+    if (!sourceDeck) {
+      return NextResponse.json({ error: "Deck not found" }, { status: 404 });
+    }
+
+    // Permission: allow copying public decks or user's own private decks
+    const isOwner = sourceDeck.userId.toString() === session.user.id;
+    if (!sourceDeck.isPublic && !isOwner) {
+      return NextResponse.json(
+        { error: "You do not have permission to copy this deck" },
+        { status: 403 }
+      );
+    }
+
+    // Get owner info for attribution in the name
+    const ownerInfo = await deckDbService.getDeckUserInfo(
+      sourceDeck.userId.toString()
+    );
+    const ownerAttribution = ownerInfo.username || ownerInfo.name || "Unknown";
+
+    // Build the new deck payload
+    const newDeckPayload = {
+      name: `${sourceDeck.name} (Copy from ${ownerAttribution})`,
+      description: sourceDeck.description || "",
+      // youtubeUrl intentionally cleared
+      userId: new ObjectId(session.user.id),
+      cards: sourceDeck.cards.map((c) => ({ cardId: c.cardId, quantity: c.quantity })),
+      isPublic: false, // default to private
+    };
+
+    const newDeck = await deckService.createDeck(newDeckPayload);
+
+    return NextResponse.json({ deckId: newDeck._id.toString() }, { status: 201 });
+  } catch (error) {
+    console.error("Error copying deck:", error);
+    return NextResponse.json(
+      { error: "Failed to copy deck" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, Suspense } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { GuestDeckMigration } from "@/app/lib/utils/guestDeckMigration";
 import { toast, Toaster } from "react-hot-toast";
 
-export default function AuthCallback() {
+function AuthCallbackInner() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -84,4 +84,21 @@ export default function AuthCallback() {
   }
 
   return <Toaster position='top-right' />;
+}
+
+export default function AuthCallback() {
+  return (
+    <Suspense
+      fallback={
+        <div className='flex justify-center items-center min-h-[calc(100vh-64px)]'>
+          <Toaster position='top-right' />
+          <div className='text-center'>
+            <div className='animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-algomancy-purple mx-auto mb-4'></div>
+            <p className='text-white text-lg'>Loading…</p>
+          </div>
+        </div>
+      }>
+      <AuthCallbackInner />
+    </Suspense>
+  );
 }

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,15 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { GuestDeckMigration } from "@/app/lib/utils/guestDeckMigration";
 import { toast, Toaster } from "react-hot-toast";
 
 export default function AuthCallback() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isProcessing, setIsProcessing] = useState(true);
+
+  const returnTo = useMemo(() => {
+    const rt = searchParams?.get("returnTo");
+    return rt && rt.length > 0 ? rt : "/";
+  }, [searchParams]);
 
   useEffect(() => {
     const handleCallback = async () => {
@@ -54,13 +60,13 @@ export default function AuthCallback() {
           }
         }
 
-        // No migration needed or migration failed, go to homepage
-        router.push("/");
+        // No migration needed or migration failed, go to target page
+        router.push(returnTo || "/");
       }
     };
 
     handleCallback();
-  }, [status, session, router]);
+  }, [status, session, router, returnTo]);
 
   if (status === "loading" || isProcessing) {
     return (

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,17 +1,24 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { signIn } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { GuestDeckMigration } from "@/app/lib/utils/guestDeckMigration";
 
 export default function SignIn() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+
+  const callbackUrl = useMemo(() => {
+    const cb = searchParams?.get("callbackUrl") || searchParams?.get("returnTo");
+    // Fallback to homepage
+    return cb && cb.length > 0 ? cb : "/";
+  }, [searchParams]);
 
   const login = useCallback(async () => {
     try {
@@ -25,7 +32,7 @@ export default function SignIn() {
         email,
         password,
         redirect: false,
-        callbackUrl: "/",
+        callbackUrl,
       });
 
       if (result?.error) {
@@ -47,7 +54,7 @@ export default function SignIn() {
         }
       }
 
-      router.push("/");
+      router.push(callbackUrl || "/");
     } catch (error) {
       console.error(error);
       setError("An unexpected error occurred");
@@ -157,7 +164,8 @@ export default function SignIn() {
                       "true"
                     );
                   }
-                  signIn("google", { callbackUrl: "/auth/callback" });
+                  const returnTo = callbackUrl && callbackUrl !== "/" ? `?returnTo=${encodeURIComponent(callbackUrl)}` : "";
+                  signIn("google", { callbackUrl: `/auth/callback${returnTo}` });
                 }}
                 className='w-full flex justify-center py-2 px-4 border border-algomancy-purple/30 rounded-md shadow-sm text-sm font-medium text-white bg-algomancy-dark hover:bg-algomancy-dark/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-algomancy-purple'>
                 <svg className='w-5 h-5 mr-2' viewBox='0 0 24 24'>

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, Suspense } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { GuestDeckMigration } from "@/app/lib/utils/guestDeckMigration";
 
-export default function SignIn() {
+function SignInInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
@@ -181,5 +181,21 @@ export default function SignIn() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function SignIn() {
+  return (
+    <Suspense
+      fallback={
+        <div className='flex justify-center items-center min-h-[calc(100vh-64px)]'>
+          <div className='text-center'>
+            <div className='animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-algomancy-purple mx-auto mb-4'></div>
+            <p className='text-white text-lg'>Loading…</p>
+          </div>
+        </div>
+      }>
+      <SignInInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
This PR implements the Copy Deck feature and consolidates deck actions into a single dropdown.

Changes
- API: `POST /api/decks/[id]/copy`
  - Auth required; allows copying public decks or owner’s private decks
  - Clears `youtubeUrl`, sets `isPublic: false` by default
  - Resets metrics (likes/views) via schema defaults
  - Appends “(Copy from {owner})” to name

- Deck detail UI (`/decks/[id]`):
  - Adds a single “Options” dropdown aligned to the far right of the header
  - Menu: Copy Deck, Export deck .txt, Export deck .tss; owner-only: Edit, Delete
  - Improved hover visibility, click-outside and Escape-to-close

- Auth flow polish:
  - Sign-in honors `callbackUrl`/`returnTo`
  - If logged out → Copy → Sign-in → return to deck → auto-copy → redirect to `/decks/{newId}/edit`
  - Wrapped signin/callback pages with Suspense to satisfy Next.js `useSearchParams` CSR bailout

Verification
- Logged in: Copy from deck page redirects to the new deck’s edit page
- Logged out: After login, returns to deck, auto-copies once, and redirects to edit
- Vercel build passes (green)

Notes
- `.tss` is a JSON stub for now; real TTS export can follow.